### PR TITLE
Update thesis.tex

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -7,6 +7,11 @@
 \usepackage{latexsym}
 \usepackage{amssymb,amsthm,amsmath}
 \usepackage[notocbib]{apacite}
+
+\AtBeginDocument{%
+\renewcommand{\BBAY}{, }%% punctuation between authors and year
+}
+
 \usepackage{verbatim}
 \usepackage{multirow}
 \usepackage{bm}


### PR DESCRIPTION
`\fullcite{text}` fails for spacing between the authors and year. So adding this line to override `apacite.sty`